### PR TITLE
Update emr_cluster.html.markdown

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -238,15 +238,19 @@ resource "aws_emr_instance_fleet" "task" {
 resource "aws_emr_cluster" "example" {
   # ... other configuration ...
 
-  step {
-    action_on_failure = "TERMINATE_CLUSTER"
-    name              = "Setup Hadoop Debugging"
+  step = [ 
+    {
+      action_on_failure = "TERMINATE_CLUSTER"
+      name              = "Setup Hadoop Debugging"
 
-    hadoop_jar_step {
-      jar  = "command-runner.jar"
-      args = ["state-pusher-script"]
+      hadoop_jar_step = [
+        {
+          jar  = "command-runner.jar"
+          args = ["state-pusher-script"]
+        }
+      ]
     }
-  }
+  ]
 
   # Optional: ignore outside changes to running cluster steps
   lifecycle {


### PR DESCRIPTION
### Description
Addresses Issue [#735](https://github.com/figma/terraform-provider-aws-4-49-0/issues/735) `[Docs]: Outdated documentation for aws_emr_cluster step and hadoop_jar_step variables`.

Under the section [Enable Debug Logging(https://registry.terraform.io/providers/figma/aws-4-49-0/latest/docs/resources/emr_cluster#enable-debug-logging), step and hadoop_jar_step requires a list instead of a map.

It should be updated from:
```
resource "aws_emr_cluster" "example" {
  # ... other configuration ...

  step {
    action_on_failure = "TERMINATE_CLUSTER"
    name              = "Setup Hadoop Debugging"

    hadoop_jar_step {
      jar  = "command-runner.jar"
      args = ["state-pusher-script"]
    }
  }

  # Optional: ignore outside changes to running cluster steps
  lifecycle {
    ignore_changes = [step]
  }
}
```

To the following:
```
resource "aws_emr_cluster" "example" {
  # ... other configuration ...

  step = [{
    action_on_failure = "TERMINATE_CLUSTER"
    name              = "Setup Hadoop Debugging"

    hadoop_jar_step = [{
      jar  = "command-runner.jar"
      args = ["state-pusher-script"]
    }]
  }]

  # Optional: ignore outside changes to running cluster steps
  lifecycle {
    ignore_changes = [step]
  }
}
```

For step, this is also supported by the [aws emr create-cluster documentation](https://docs.aws.amazon.com/cli/latest/reference/emr/create-cluster.html) where `--step` requires a list of steps to be executed by the cluster.

Error received when a map is submitted to the step variable:
<img width="762" alt="step_error" src="https://github.com/figma/terraform-provider-aws-4-49-0/assets/52845474/e8cac70c-b3ca-438b-81e8-eaf9f90deb92">

Error received when a map is submitted to the hadoop_jar_step variable:
<img width="758" alt="hadoop_jar_step_error" src="https://github.com/figma/terraform-provider-aws-4-49-0/assets/52845474/257ff944-1230-4f2d-ab8d-ccfa37133e80">

No CHANGELOG.md update as it is a documentation update.

### Relations
Closes #735

### References
https://docs.aws.amazon.com/cli/latest/reference/emr/create-cluster.html

### Output from Acceptance Testing
Does not affect tests as it is a documentation update.